### PR TITLE
1089 Axis Width to override default behaviour

### DIFF
--- a/Core/AxisCore.cs
+++ b/Core/AxisCore.cs
@@ -180,6 +180,11 @@ namespace LiveCharts
         /// </value>
         public double S { get; internal set; }
 
+        /// <summary>
+        /// Gets or sets the Axis fixed width.
+        /// </summary>
+        public double Width { get; set; }
+
         #endregion
 
         #region Internal Properties

--- a/Core/Charts/ChartCore.cs
+++ b/Core/Charts/ChartCore.cs
@@ -241,6 +241,10 @@ namespace LiveCharts.Charts
                 var ax = AxisY[index];
                 var titleSize = ax.View.UpdateTitle(this, -90d);
                 var biggest = ax.PrepareChart(AxisOrientation.Y, this);
+                if (!double.IsNaN(ax.Width))
+                {
+                    biggest.Width = ax.Width;
+                }
 
                 var x = curSize.Left;
 

--- a/Core40/AxisCore.cs
+++ b/Core40/AxisCore.cs
@@ -180,6 +180,11 @@ namespace LiveCharts
         /// </value>
         public double S { get; internal set; }
 
+        /// <summary>
+        /// Gets or sets the Axis fixed width.
+        /// </summary>
+        public double Width { get; set; }
+
         #endregion
 
         #region Internal Properties

--- a/Core40/Charts/ChartCore.cs
+++ b/Core40/Charts/ChartCore.cs
@@ -242,6 +242,10 @@ namespace LiveCharts.Charts
                 var ax = AxisY[index];
                 var titleSize = ax.View.UpdateTitle(this, -90d);
                 var biggest = ax.PrepareChart(AxisOrientation.Y, this);
+                if (!double.IsNaN(ax.Width))
+                {
+                    biggest.Width = ax.Width;
+                }
 
                 var x = curSize.Left;
 

--- a/Examples/Wpf/CartesianChart/AxisFixedWidth/AxisFixedWidthExample.xaml
+++ b/Examples/Wpf/CartesianChart/AxisFixedWidth/AxisFixedWidthExample.xaml
@@ -1,0 +1,54 @@
+﻿<UserControl x:Class="Wpf.CartesianChart.AxisFixedWidth.AxisFixedWidthExample"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:lvc="clr-namespace:LiveCharts.Wpf;assembly=LiveCharts.Wpf"
+             mc:Ignorable="d" 
+             d:DesignHeight="300" d:DesignWidth="300">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <lvc:CartesianChart Grid.Row="0"
+                            Series="{Binding ChartOneSeriesCollection}" 
+                            LegendLocation="Right">
+            <lvc:CartesianChart.AxisY>
+                <lvc:Axis Title="USA Sales" LabelFormatter="{Binding YFormatter}" />
+            </lvc:CartesianChart.AxisY>
+            <lvc:CartesianChart.AxisX>
+                <lvc:Axis Title="Month" Labels="{Binding Labels}" />
+            </lvc:CartesianChart.AxisX>
+        </lvc:CartesianChart>
+
+        <lvc:CartesianChart Grid.Row="1"
+                            Series="{Binding ChartTwoSeriesCollection}" 
+                            LegendLocation="Right">
+            <lvc:CartesianChart.AxisY>
+                <lvc:Axis Title="UK Sales"
+                          Width="100" />
+            </lvc:CartesianChart.AxisY>
+            <lvc:CartesianChart.AxisX>
+                <lvc:Axis Title="Month"/>
+            </lvc:CartesianChart.AxisX>
+        </lvc:CartesianChart>
+
+        <lvc:CartesianChart Grid.Row="2"
+                            Series="{Binding ChartThreeSeriesCollection}" 
+                            LegendLocation="Right">
+            <lvc:CartesianChart.AxisY>
+                <lvc:Axis Title="EU Sales"
+                          Width="100" />
+            </lvc:CartesianChart.AxisY>
+            <lvc:CartesianChart.AxisX>
+                <lvc:Axis Title="Month"/>
+            </lvc:CartesianChart.AxisX>
+        </lvc:CartesianChart>
+    </Grid>
+</UserControl>
+
+
+

--- a/Examples/Wpf/CartesianChart/AxisFixedWidth/AxisFixedWidthExample.xaml.cs
+++ b/Examples/Wpf/CartesianChart/AxisFixedWidth/AxisFixedWidthExample.xaml.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Windows.Controls;
+using System.Windows.Media;
+using LiveCharts;
+using LiveCharts.Wpf;
+
+namespace Wpf.CartesianChart.AxisFixedWidth
+{
+    /// <summary>
+    /// Interaction logic for WindowAxisExample.xaml
+    /// </summary>
+    public partial class AxisFixedWidthExample : UserControl
+    {
+        private readonly Random _random;
+        private readonly Brush[] _brushes = {
+            Brushes.Aqua,
+            Brushes.YellowGreen,
+            Brushes.HotPink,
+            Brushes.Gold,
+            Brushes.Crimson,
+            Brushes.DodgerBlue,
+            Brushes.CadetBlue,
+            Brushes.DarkSlateBlue
+        };
+        public AxisFixedWidthExample()
+        {
+            InitializeComponent();
+
+            _random = new Random();
+
+            ChartOneSeriesCollection = GenerateSeriesCollection();
+            ChartTwoSeriesCollection = GenerateSeriesCollection();
+            ChartThreeSeriesCollection = GenerateSeriesCollection();
+
+            DataContext = this;
+        }
+
+        private SeriesCollection GenerateSeriesCollection()
+        {
+            return new SeriesCollection
+            {
+                new LineSeries
+                {
+                    Title = "Series 1",
+                    Values = new ChartValues<int>(RandomArray(5, 10)),
+                    Stroke = RandomBrush()
+
+                },
+                new LineSeries
+                {
+                    Title = "Series 2",
+                    Values = new ChartValues<int>( RandomArray(5, 10)),
+                    Stroke = RandomBrush()
+                }
+            };
+
+        }
+
+        private IEnumerable<int> RandomArray(int size, int range)
+        {
+
+            var array = new int[size];
+
+            for (var i = 0; i < size; i++)
+            {
+                array[i] = _random.Next(0, range);
+            }
+
+            return array;
+        }
+
+        private Brush RandomBrush()
+        {
+            var random = _random.Next(_brushes.Length);
+
+            return _brushes[random];
+        }
+
+        public SeriesCollection ChartOneSeriesCollection { get; set; }
+        public SeriesCollection ChartTwoSeriesCollection { get; set; }
+        public SeriesCollection ChartThreeSeriesCollection { get; set; }
+        public string[] Labels { get; set; }
+        public Func<double, string> YFormatter { get; set; }
+    }
+}

--- a/Examples/Wpf/Home/HomeViewModel.cs
+++ b/Examples/Wpf/Home/HomeViewModel.cs
@@ -9,6 +9,7 @@ using System.Windows.Data;
 using LiveCharts.Defaults;
 using LiveCharts.Wpf;
 using Wpf.CartesianChart;
+using Wpf.CartesianChart.AxisFixedWidth;
 using Wpf.CartesianChart.BasicLine;
 using Wpf.CartesianChart.Basic_Bars;
 using Wpf.CartesianChart.Basic_Stacked_Bar;
@@ -121,7 +122,8 @@ namespace Wpf.Home
                         new SampleVm("Events", typeof(EventsExample)),
                         new SampleVm("Visual Elements", typeof(UiElementsAndEventsExample)),
                         new SampleVm("Chart to Image", typeof(ChartToImageSample)),
-                        new SampleVm("DataLabelTemplate", typeof(DataLabelTemplateSample))
+                        new SampleVm("DataLabelTemplate", typeof(DataLabelTemplateSample)),
+                        new SampleVm("Fixed Width Axis", typeof(AxisFixedWidthExample)), 
                     }
                 },
                 new SampleGroupVm

--- a/WpfView/Axis.cs
+++ b/WpfView/Axis.cs
@@ -634,6 +634,7 @@ namespace LiveCharts.Wpf
             Model.Separator = Separator.AsCoreElement(Model, source);
             Model.DisableAnimations = DisableAnimations;
             Model.Sections = Sections.Select(x => x.AsCoreElement(Model, source)).ToList();
+            Model.Width = Width;
 
             return Model;
         }


### PR DESCRIPTION
#### Summary

Previously the `Axis` `Width` was decided based on its biggest items `Width`. 

Now if the `Axis` `Width` is set to a value  it will use that, else it falls back to the default behaviour.

N.B. Setting `Axis` `Width` to `NaN` will result in the default behaviour.

#### Solves 

Now you can set the `Axis` `Width` it is easier to align multiple graphs without needing to nest them or use `IsMerged` property.

https://stackoverflow.com/questions/46877065/align-two-cartisian-charts-with-different-axis-label-width

#1089
