### PR TITLE
Implemented the ability to set PointStroke for a LineSeries

### DIFF
--- a/Examples/Wpf/CartesianChart/PointStroke/PointStrokeExample.xaml
+++ b/Examples/Wpf/CartesianChart/PointStroke/PointStrokeExample.xaml
@@ -1,0 +1,22 @@
+﻿<UserControl x:Class="Wpf.CartesianChart.PointStroke.PointStrokeExample"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:lvc="clr-namespace:LiveCharts.Wpf;assembly=LiveCharts.Wpf"
+             mc:Ignorable="d" 
+             d:DesignHeight="300" d:DesignWidth="300">
+    <Grid>
+        <lvc:CartesianChart Series="{Binding SeriesCollection}" 
+                            LegendLocation="Right">
+            <lvc:CartesianChart.AxisY>
+                <lvc:Axis Title="Sales" 
+                          LabelFormatter="{Binding YFormatter}" />
+            </lvc:CartesianChart.AxisY>
+            <lvc:CartesianChart.AxisX>
+                <lvc:Axis Title="Month" 
+                          Labels="{Binding Labels}" />
+            </lvc:CartesianChart.AxisX>
+        </lvc:CartesianChart>
+    </Grid>
+</UserControl>

--- a/Examples/Wpf/CartesianChart/PointStroke/PointStrokeExample.xaml.cs
+++ b/Examples/Wpf/CartesianChart/PointStroke/PointStrokeExample.xaml.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Windows.Controls;
+using System.Windows.Media;
+
+using LiveCharts;
+using LiveCharts.Wpf;
+
+namespace Wpf.CartesianChart.PointStroke
+{
+    /// <summary>
+    /// Interaction logic for WindowAxisExample.xaml
+    /// </summary>
+    public partial class PointStrokeExample : UserControl
+    {
+        public PointStrokeExample()
+        {
+            InitializeComponent();
+
+            SeriesCollection = GenerateSeriesCollection();
+
+            DataContext = this;
+        }
+
+        private SeriesCollection GenerateSeriesCollection()
+        {
+            var series1 = new double[] {2, 4, 6, 8, 1};
+
+            var series2 = new [] { double.NaN,
+                                          series1[1],
+                                          double.NaN,
+                                          double.NaN,
+                                          series1[4]
+            };
+
+            var series3 = new[] { double.NaN,
+                                         double.NaN,
+                                         series1[2],
+                                         double.NaN,
+                                         double.NaN
+            }; 
+
+            return new SeriesCollection
+            {
+                new LineSeries
+                {
+                    Title = "Series 1",
+                    Values = new ChartValues<double>(series1)
+                },
+                new LineSeries
+                {
+                    Title = "Series 2",
+                    Values = new ChartValues<double>(series2),
+                    PointStroke = Brushes.Red
+                },
+                new LineSeries
+                {
+                    Title = "Series 3",
+                    Values = new ChartValues<double>(series3),
+                    PointStroke = Brushes.Green,
+                    PointForeground = Brushes.Yellow
+                }
+            };
+        }
+
+        public SeriesCollection SeriesCollection { get; set; }
+        public string[] Labels { get; set; }
+        public Func<double, string> YFormatter { get; set; }
+    }
+}

--- a/Examples/Wpf/Home/HomeViewModel.cs
+++ b/Examples/Wpf/Home/HomeViewModel.cs
@@ -37,6 +37,7 @@ using Wpf.CartesianChart.MaterialCards;
 using Wpf.CartesianChart.Missing_Line_Points;
 using Wpf.CartesianChart.NegativeStackedRow;
 using Wpf.CartesianChart.PointState;
+using Wpf.CartesianChart.PointStroke;
 using Wpf.CartesianChart.ScatterPlot;
 using Wpf.CartesianChart.Scatter_With_Pies;
 using Wpf.CartesianChart.Sections;
@@ -124,6 +125,7 @@ namespace Wpf.Home
                         new SampleVm("Chart to Image", typeof(ChartToImageSample)),
                         new SampleVm("DataLabelTemplate", typeof(DataLabelTemplateSample)),
                         new SampleVm("Fixed Width Axis", typeof(AxisFixedWidthExample)), 
+                        new SampleVm("Point Stroke", typeof(PointStrokeExample))
                     }
                 },
                 new SampleGroupVm

--- a/Examples/Wpf/Wpf.csproj
+++ b/Examples/Wpf/Wpf.csproj
@@ -90,4 +90,9 @@
   <ItemGroup>
     <Folder Include="CartesianChart\CustomZoomingAndPanning\" />
   </ItemGroup>
+  <ItemGroup>
+    <Page Update="CartesianChart\PointStroke\PointStrokeExample.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+  </ItemGroup>
 </Project>

--- a/WpfView/Charts/Base/Chart.cs
+++ b/WpfView/Charts/Base/Chart.cs
@@ -971,7 +971,7 @@ namespace LiveCharts.Wpf.Charts.Base
                                      x.SeriesView is IStackedAreaSeriesView)
                                 ? ((IFondeable) x.SeriesView).PointForeground
                                 : ((Series) x.SeriesView).Fill,
-                            Stroke = ((Series) x.SeriesView).Stroke,
+                            Stroke = ((Series) x.SeriesView).PointStroke ?? ((Series)x.SeriesView).Stroke,
                             StrokeThickness = ((Series) x.SeriesView).StrokeThickness,
                             Title = ((Series) x.SeriesView).Title,
                         },
@@ -1052,7 +1052,9 @@ namespace LiveCharts.Wpf.Charts.Base
 
                 item.Title = series.Title;
                 item.StrokeThickness = series.StrokeThickness;
-                item.Stroke = series.Stroke;
+
+                item.Stroke = series.PointStroke ?? series.Stroke;
+
                 item.Fill = ((Series) t) is IFondeable &&
                             !(t is IVerticalStackedAreaSeriesView ||
                               t is IStackedAreaSeriesView)

--- a/WpfView/Charts/Base/Chart.cs
+++ b/WpfView/Charts/Base/Chart.cs
@@ -1052,9 +1052,7 @@ namespace LiveCharts.Wpf.Charts.Base
 
                 item.Title = series.Title;
                 item.StrokeThickness = series.StrokeThickness;
-
                 item.Stroke = series.PointStroke ?? series.Stroke;
-
                 item.Fill = ((Series) t) is IFondeable &&
                             !(t is IVerticalStackedAreaSeriesView ||
                               t is IStackedAreaSeriesView)

--- a/WpfView/LineSeries.cs
+++ b/WpfView/LineSeries.cs
@@ -290,7 +290,7 @@ namespace LiveCharts.Wpf
             if (pbv.Shape != null)
             {
                 pbv.Shape.Fill = PointForeground;
-                pbv.Shape.Stroke = Stroke;
+                pbv.Shape.Stroke = PointStroke ?? Stroke;
                 pbv.Shape.StrokeThickness = StrokeThickness;
                 pbv.Shape.Width = PointGeometrySize;
                 pbv.Shape.Height = PointGeometrySize;

--- a/WpfView/Series.cs
+++ b/WpfView/Series.cs
@@ -348,6 +348,22 @@ namespace LiveCharts.Wpf
         }
 
         /// <summary>
+        /// The point stroke property
+        /// </summary>
+        public static readonly DependencyProperty PointStrokeProperty = DependencyProperty.Register(
+            "PointStroke", typeof(Brush), typeof(Series),
+            new PropertyMetadata(null, CallChartUpdater()));
+
+        /// <summary>
+        /// Gets or sets series point stroke, if this property is null then the <see cref="PointStroke"/> will be that of the set value of <see cref="Stroke"/>. 
+        /// </summary>
+        public Brush PointStroke
+        {
+            get { return (Brush)GetValue(PointStrokeProperty); }
+            set { SetValue(PointStrokeProperty, value); }
+        }
+
+        /// <summary>
         /// The scales x at property
         /// </summary>
         public static readonly DependencyProperty ScalesXAtProperty = DependencyProperty.Register(
@@ -488,7 +504,7 @@ namespace LiveCharts.Wpf
         {
             var wpfChart = (Chart) Model.Chart.View;
 
-            if (Stroke != null && Fill != null) return;
+            if (Stroke != null && Fill != null && PointStroke != null) return;
 
             var nextColor = wpfChart.GetNextDefaultColor();
 
@@ -506,6 +522,12 @@ namespace LiveCharts.Wpf
                 SetValue(FillProperty, fillBursh);
             }
 
+            if (PointStroke == null)
+            {
+                var pointStroke = new SolidColorBrush(nextColor) { Opacity = DefaultFillOpacity };
+                pointStroke.Freeze();
+                SetValue(FillProperty, pointStroke);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
#### Summary

Implemented the ability to set the  `PointStroke` for a `LineSeries` _(might work for others, but not tested)_.

If `PointStroke` is not set then it falls back to the `LinesSeries`'s `Stroke` value.

_N.B. I have not tested it in conjunction with a `Mapper`, seeing as it overrides the `Stroke` value I expect it to take precedence._

Although I do realise you can set the `PointStroke` by using a `Mapper` which is illustrated in the documentation below; 

https://lvcharts.net/App/examples/v1/wpf/Point%20State

It did not fit my requirements where my current data in my prototype is fragmented so for ease of use I am layering series over the top of each other. i.e. I have the base series, and then another with specific markers. Which works, however I wanted to show the difference between markers with Hollow, and Full shapes which is where the ability to set `PointStroke` comes in. 

I think with a pre-sorted data using a `Mapper` might be more efficient, I would need to profile the difference between the two.

#### Solves 

#636
