### PR TITLE
Implemented PointStrokeDashArray for LineSeries.

### DIFF
--- a/Examples/Wpf/CartesianChart/PointStrokeDashArray/PointStrokeDashArrayExample.xaml
+++ b/Examples/Wpf/CartesianChart/PointStrokeDashArray/PointStrokeDashArrayExample.xaml
@@ -1,0 +1,22 @@
+﻿<UserControl x:Class="Wpf.CartesianChart.PointStrokeDashArray.PointStrokeDashArrayExample"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:lvc="clr-namespace:LiveCharts.Wpf;assembly=LiveCharts.Wpf"
+             mc:Ignorable="d" 
+             d:DesignHeight="300" d:DesignWidth="300">
+    <Grid>
+        <lvc:CartesianChart Series="{Binding SeriesCollection}" 
+                            LegendLocation="Right">
+            <lvc:CartesianChart.AxisY>
+                <lvc:Axis Title="Sales" 
+                          LabelFormatter="{Binding YFormatter}" />
+            </lvc:CartesianChart.AxisY>
+            <lvc:CartesianChart.AxisX>
+                <lvc:Axis Title="Month" 
+                          Labels="{Binding Labels}" />
+            </lvc:CartesianChart.AxisX>
+        </lvc:CartesianChart>
+    </Grid>
+</UserControl>

--- a/Examples/Wpf/CartesianChart/PointStrokeDashArray/PointStrokeDashArrayExample.xaml.cs
+++ b/Examples/Wpf/CartesianChart/PointStrokeDashArray/PointStrokeDashArrayExample.xaml.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Windows.Controls;
+using System.Windows.Media;
+
+using LiveCharts;
+using LiveCharts.Wpf;
+
+namespace Wpf.CartesianChart.PointStrokeDashArray
+{
+    /// <summary>
+    /// Interaction logic for WindowAxisExample.xaml
+    /// </summary>
+    public partial class PointStrokeDashArrayExample : UserControl
+    {
+        public PointStrokeDashArrayExample()
+        {
+            InitializeComponent();
+
+            SeriesCollection = GenerateSeriesCollection();
+
+            DataContext = this;
+        }
+
+        private SeriesCollection GenerateSeriesCollection()
+        {
+            var series1 = new double[] { 5, 7, 6, 8, 4 };
+
+            var series1Marking = new [] { double.NaN,
+                                          series1[1],
+                                          double.NaN,
+                                          series1[3],
+                                          double.NaN,
+            };
+
+            var series2 = new double[] { 2, 4, 1, 5, 3 };
+
+            return new SeriesCollection
+            {
+                new LineSeries
+                {
+                    Title = "No StrokeDashArray",
+                    Values = new ChartValues<double>(series1),
+                    PointGeometry = null
+                },
+                new LineSeries
+                {
+                    Title = "PointStrokeDashArray",
+                    Values = new ChartValues<double>(series1Marking),
+                    PointGeometrySize = 15, 
+                    PointForeground = Brushes.Transparent,
+                    PointStrokeDashArray = new DoubleCollection { 2, 1 }
+                },
+                new LineSeries
+                {
+                    Title = "Point & Series StrokeDashArray",
+                    Values = new ChartValues<double>(series2),
+                    PointGeometrySize = 15,
+                    StrokeDashArray = new DoubleCollection { 1 },
+                    PointStroke = Brushes.Green,
+                    PointForeground = Brushes.Transparent,
+                    PointStrokeDashArray = new DoubleCollection { 0.5, 1 }
+                }
+            };
+        }
+
+        public SeriesCollection SeriesCollection { get; set; }
+        public string[] Labels { get; set; }
+        public Func<double, string> YFormatter { get; set; }
+    }
+}

--- a/Examples/Wpf/Home/HomeViewModel.cs
+++ b/Examples/Wpf/Home/HomeViewModel.cs
@@ -38,6 +38,7 @@ using Wpf.CartesianChart.Missing_Line_Points;
 using Wpf.CartesianChart.NegativeStackedRow;
 using Wpf.CartesianChart.PointState;
 using Wpf.CartesianChart.PointStroke;
+using Wpf.CartesianChart.PointStrokeDashArray;
 using Wpf.CartesianChart.ScatterPlot;
 using Wpf.CartesianChart.Scatter_With_Pies;
 using Wpf.CartesianChart.Sections;
@@ -80,7 +81,9 @@ namespace Wpf.Home
                         new SampleVm("Material Design", typeof(MaterialCards)),
                         new SampleVm("Solid Color", typeof(SolidColorExample)),
                         new SampleVm("Energy Predictions", typeof(EnergyPredictionExample)),
-                        new SampleVm("Funnel Chart", typeof(FunnelExample))
+                        new SampleVm("Funnel Chart", typeof(FunnelExample)),
+                        new SampleVm("Point Stroke", typeof(PointStrokeExample)),
+                        new SampleVm("Point StrokeDashArray", typeof(PointStrokeDashArrayExample)) 
                     }
                 },
                 new SampleGroupVm
@@ -124,8 +127,7 @@ namespace Wpf.Home
                         new SampleVm("Visual Elements", typeof(UiElementsAndEventsExample)),
                         new SampleVm("Chart to Image", typeof(ChartToImageSample)),
                         new SampleVm("DataLabelTemplate", typeof(DataLabelTemplateSample)),
-                        new SampleVm("Fixed Width Axis", typeof(AxisFixedWidthExample)), 
-                        new SampleVm("Point Stroke", typeof(PointStrokeExample))
+                        new SampleVm("Fixed Width Axis", typeof(AxisFixedWidthExample))
                     }
                 },
                 new SampleGroupVm

--- a/Examples/Wpf/Wpf.csproj
+++ b/Examples/Wpf/Wpf.csproj
@@ -91,6 +91,9 @@
     <Folder Include="CartesianChart\CustomZoomingAndPanning\" />
   </ItemGroup>
   <ItemGroup>
+    <Page Update="CartesianChart\PointStrokeDashArray\PointStrokeDashArrayExample.xaml">
+      <SubType>Designer</SubType>
+    </Page>
     <Page Update="CartesianChart\PointStroke\PointStrokeExample.xaml">
       <SubType>Designer</SubType>
     </Page>

--- a/WpfView/Charts/Base/Chart.cs
+++ b/WpfView/Charts/Base/Chart.cs
@@ -973,6 +973,7 @@ namespace LiveCharts.Wpf.Charts.Base
                                 : ((Series) x.SeriesView).Fill,
                             Stroke = ((Series) x.SeriesView).PointStroke ?? ((Series)x.SeriesView).Stroke,
                             StrokeThickness = ((Series) x.SeriesView).StrokeThickness,
+                            StrokeDashArray = ((Series)x.SeriesView).PointStrokeDashArray ?? ((Series)x.SeriesView).StrokeDashArray,
                             Title = ((Series) x.SeriesView).Title,
                         },
                         ChartPoint = x
@@ -1053,6 +1054,7 @@ namespace LiveCharts.Wpf.Charts.Base
                 item.Title = series.Title;
                 item.StrokeThickness = series.StrokeThickness;
                 item.Stroke = series.PointStroke ?? series.Stroke;
+                item.StrokeDashArray = series.PointStrokeDashArray ?? series.StrokeDashArray;
                 item.Fill = ((Series) t) is IFondeable &&
                             !(t is IVerticalStackedAreaSeriesView ||
                               t is IStackedAreaSeriesView)

--- a/WpfView/DefaultLegend.xaml
+++ b/WpfView/DefaultLegend.xaml
@@ -63,7 +63,9 @@
                                 <Path Width="{Binding BulletSize, RelativeSource={RelativeSource Mode=FindAncestor, AncestorLevel=1, AncestorType={x:Type UserControl}}}" 
                                          Height="{Binding BulletSize, RelativeSource={RelativeSource Mode=FindAncestor, AncestorLevel=1, AncestorType={x:Type UserControl}}}" 
                                          StrokeThickness="{Binding StrokeThickness}" 
-                                         Stroke="{Binding Stroke}" Fill="{Binding Fill}"
+                                         Stroke="{Binding Stroke}" 
+                                         Fill="{Binding Fill}"
+                                         StrokeDashArray="{Binding StrokeDashArray}"
                                          Stretch="Fill" Data="{Binding PointGeometry}"/>
                                 <TextBlock Grid.Column="1" Margin="4 0" Text="{Binding Title}" VerticalAlignment="Center" />
                             </Grid>

--- a/WpfView/DefaultTooltip.xaml
+++ b/WpfView/DefaultTooltip.xaml
@@ -88,7 +88,9 @@
                                         <Path Width="{Binding BulletSize, RelativeSource={RelativeSource Mode=FindAncestor, AncestorLevel=1, AncestorType={x:Type UserControl}}}" 
                                              Height="{Binding BulletSize, RelativeSource={RelativeSource Mode=FindAncestor, AncestorLevel=1, AncestorType={x:Type UserControl}}}" 
                                              StrokeThickness="{Binding Series.StrokeThickness}" 
-                                             Stroke="{Binding Series.Stroke}" Fill="{Binding Series.Fill}" 
+                                             Stroke="{Binding Series.Stroke}" 
+                                             StrokeDashArray="{Binding Series.StrokeDashArray}"
+                                             Fill="{Binding Series.Fill}" 
                                              Stretch="Fill" Data="{Binding Series.PointGeometry}"
                                              Visibility="{Binding ShowSeries, ElementName=Control, Converter={StaticResource Bvc}}"/>
                                         <TextBlock Grid.Column="1" Text="{Binding Series.Title}" VerticalAlignment="Center" Margin="5 0 5 0"

--- a/WpfView/DefaultTooltip.xaml.cs
+++ b/WpfView/DefaultTooltip.xaml.cs
@@ -433,6 +433,12 @@ namespace LiveCharts.Wpf
         /// Series Stroke thickness
         /// </summary>
         public double StrokeThickness { get; set; }
+
+        /// <summary>
+        /// Series Stroke Dash Array
+        /// </summary>
+        public DoubleCollection StrokeDashArray { get; set; }
+        
         /// <summary>
         /// Series Fill
         /// </summary>

--- a/WpfView/LineSeries.cs
+++ b/WpfView/LineSeries.cs
@@ -291,6 +291,7 @@ namespace LiveCharts.Wpf
             {
                 pbv.Shape.Fill = PointForeground;
                 pbv.Shape.Stroke = PointStroke ?? Stroke;
+                pbv.Shape.StrokeDashArray = PointStrokeDashArray ?? StrokeDashArray;
                 pbv.Shape.StrokeThickness = StrokeThickness;
                 pbv.Shape.Width = PointGeometrySize;
                 pbv.Shape.Height = PointGeometrySize;

--- a/WpfView/Series.cs
+++ b/WpfView/Series.cs
@@ -364,6 +364,21 @@ namespace LiveCharts.Wpf
         }
 
         /// <summary>
+        /// The stroke dash array property
+        /// </summary>
+        public static readonly DependencyProperty PointStrokeDashArrayProperty = DependencyProperty.Register(
+            "PointStrokeDashArray", typeof(DoubleCollection), typeof(Series),
+            new PropertyMetadata(null));
+        /// <summary>
+        /// Gets or sets the stroke dash array of a series, sue this property to draw dashed strokes
+        /// </summary>
+        public DoubleCollection PointStrokeDashArray
+        {
+            get { return (DoubleCollection)GetValue(PointStrokeDashArrayProperty); }
+            set { SetValue(PointStrokeDashArrayProperty, value); }
+        }
+
+        /// <summary>
         /// The scales x at property
         /// </summary>
         public static readonly DependencyProperty ScalesXAtProperty = DependencyProperty.Register(


### PR DESCRIPTION
#### Summary

The ability to set the `StrokeDashArray` of a `Point` rather than just the `LineSeries` by the implementation of a new property called `PointStrokeDashArray`.

If the `StrokeDashArray` is set for the `LineSeries` this is used by the `Point` as by default. If `PointStrokeDashArray` is set then this overrides the `StrokeDashArray` value for the `Point`.

I have also made changes that the `Series` in the default `Legend` and `Tooltip` now makes use of the set `StrokeDashArray`s. The `PointStrokeDashArray` will take precedent over the `StrokeDashArray` and then `Stroke`.

![PointStrokeDashArray](https://user-images.githubusercontent.com/19693277/92995991-04597c80-f500-11ea-828a-4120d875acf8.png)

#### Solves 

#1091 Point StrokeDashArray, this PR is specifically for this issue.
#843 Dashed lines appearing as Solid in the Legend, in inadvertently fixes this issue as well as adding them to the Tooltip.
