### PR TITLE
Implemented an option to always show labels for stacked columns

### DIFF
--- a/Core40/Definitions/Series/IStackedColumnSeriesView.cs
+++ b/Core40/Definitions/Series/IStackedColumnSeriesView.cs
@@ -36,6 +36,7 @@ namespace LiveCharts.Definitions.Series
         /// The maximum width of the column.
         /// </value>
         double MaxColumnWidth { get; set; }
+
         /// <summary>
         /// Gets or sets the column padding.
         /// </summary>
@@ -43,5 +44,13 @@ namespace LiveCharts.Definitions.Series
         /// The column padding.
         /// </value>
         double ColumnPadding { get; set; }
+
+        /// <summary>
+        /// Gets or sets always show labels.
+        /// </summary>
+        /// <value>
+        /// The always show labels value.
+        /// </value>
+        bool AlwaysShowLabels { get; set; }
     }
 }

--- a/Core40/SeriesAlgorithms/StackedColumnAlgorithm.cs
+++ b/Core40/SeriesAlgorithms/StackedColumnAlgorithm.cs
@@ -21,11 +21,11 @@
 //SOFTWARE.
 
 using System;
+using System.Linq;
 using LiveCharts.Defaults;
 using LiveCharts.Definitions.Points;
 using LiveCharts.Definitions.Series;
 using LiveCharts.Dtos;
-using System.Linq;
 
 namespace LiveCharts.SeriesAlgorithms
 {
@@ -95,7 +95,7 @@ namespace LiveCharts.SeriesAlgorithms
 
                 chartPoint.View = View.GetPointView(chartPoint,
                     View.DataLabels
-                        ? (chartPoint.Participation > 0.05
+                        ? (chartPoint.Participation >= 0.05
                             ? View.GetLabelPointFormatter()(chartPoint)
                             : string.Empty)
                         : null);

--- a/Examples/Wpf/CartesianChart/StackedBar/StackedColumnAlwaysShowLabelExample.xaml
+++ b/Examples/Wpf/CartesianChart/StackedBar/StackedColumnAlwaysShowLabelExample.xaml
@@ -1,0 +1,114 @@
+﻿<UserControl x:Class="Wpf.CartesianChart.StackedColumnAlwaysShowLabelExample"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:wpf="clr-namespace:LiveCharts.Wpf;assembly=LiveCharts.Wpf"
+             mc:Ignorable="d" 
+             d:DesignHeight="300" d:DesignWidth="300">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+
+        <Label Grid.Column="0"
+               Grid.Row="0"
+               Content="AlwaysShowLabels = True" />
+
+        <Label Grid.Column="0"
+               Grid.Row="1"
+               Content="StackMode.Percentage" />
+
+        <wpf:CartesianChart Grid.Column="0" 
+                            Grid.Row="2" 
+                            Series="{Binding SeriesCollectionAlwaysShowPercentage}">
+            <wpf:CartesianChart.AxisX>
+                <wpf:Axis Labels="{Binding Labels}">
+                    <wpf:Axis.Separator>
+                        <!--step 1 forces the axis to display all labels, disabling it makes it invisible-->
+                        <wpf:Separator Step="1" 
+                                       IsEnabled="False" />
+                    </wpf:Axis.Separator>
+                </wpf:Axis>
+            </wpf:CartesianChart.AxisX>
+        </wpf:CartesianChart>
+
+        <Label Grid.Column="1"
+               Grid.Row="0"
+               Content="AlwaysShowLabels = False" />
+
+        <Label Grid.Column="1"
+               Grid.Row="1"
+               Content="StackMode.Percentage" />
+
+        <wpf:CartesianChart Grid.Column="1" 
+                            Grid.Row="2" 
+                            Series="{Binding SeriesCollectionPercentage}">
+            <wpf:CartesianChart.AxisX>
+                <wpf:Axis Labels="{Binding Labels}">
+                    <wpf:Axis.Separator>
+                        <!--step 1 forces the axis to display all labels, disabling it makes it invisible-->
+                        <wpf:Separator Step="1" 
+                                       IsEnabled="False" />
+                    </wpf:Axis.Separator>
+                </wpf:Axis>
+            </wpf:CartesianChart.AxisX>
+        </wpf:CartesianChart>
+
+        <Label Grid.Column="2"
+               Grid.Row="0"
+               Content="AlwaysShowLabels = True" />
+
+        <Label Grid.Column="2"
+               Grid.Row="1"
+               Content="StackMode.Values" />
+
+        <wpf:CartesianChart Grid.Column="2" 
+                            Grid.Row="2" 
+                            Series="{Binding SeriesCollectionAlwaysShowValues}">
+            <wpf:CartesianChart.AxisY>
+                <wpf:Axis IsEnabled="False"/>
+            </wpf:CartesianChart.AxisY>
+            <wpf:CartesianChart.AxisX>
+                <wpf:Axis Labels="{Binding Labels}">
+                    <wpf:Axis.Separator>
+                        <!--step 1 forces the axis to display all labels, disabling it makes it invisible-->
+                        <wpf:Separator Step="1" 
+                                       IsEnabled="False" />
+                    </wpf:Axis.Separator>
+                </wpf:Axis>
+            </wpf:CartesianChart.AxisX>
+        </wpf:CartesianChart>
+
+        <Label Grid.Column="3"
+               Grid.Row="0"
+               Content="AlwaysShowLabels = False" />
+
+        <Label Grid.Column="3"
+               Grid.Row="1"
+               Content="StackMode.Values" />
+
+        <wpf:CartesianChart Grid.Column="3" 
+                            Grid.Row="2" 
+                            Series="{Binding SeriesCollectionValues}">
+            <wpf:CartesianChart.AxisX>
+                <wpf:Axis Labels="{Binding Labels}">
+                    <wpf:Axis.Separator>
+                        <!--step 1 forces the axis to display all labels, disabling it makes it invisible-->
+                        <wpf:Separator Step="1" 
+                                       IsEnabled="False" />
+                    </wpf:Axis.Separator>
+                </wpf:Axis>
+            </wpf:CartesianChart.AxisX>
+        </wpf:CartesianChart>
+    </Grid>
+</UserControl>

--- a/Examples/Wpf/CartesianChart/StackedBar/StackedColumnAlwaysShowLabelExample.xaml.cs
+++ b/Examples/Wpf/CartesianChart/StackedBar/StackedColumnAlwaysShowLabelExample.xaml.cs
@@ -1,0 +1,236 @@
+﻿using LiveCharts;
+using LiveCharts.Defaults;
+using LiveCharts.Wpf;
+
+namespace Wpf.CartesianChart
+{
+    /// <summary>
+    /// Interaction logic for StackedColumnAlwaysShowLabelExample.xaml
+    /// </summary>
+    public partial class StackedColumnAlwaysShowLabelExample
+    {
+        public StackedColumnAlwaysShowLabelExample()
+        {
+            InitializeComponent();
+
+            SeriesCollectionAlwaysShowPercentage = new SeriesCollection
+            {
+                new StackedColumnSeries
+                {
+                    Values = new ChartValues<ObservableValue>
+                    {
+                        new ObservableValue(1)
+                    },
+                    DataLabels = true,
+                    StackMode = StackMode.Percentage,
+                    AlwaysShowLabels = true
+                },
+                new StackedColumnSeries
+                {
+                    Values = new ChartValues<ObservableValue>
+                    {
+                        new ObservableValue(250)
+                    },
+                    DataLabels = true,
+                    StackMode = StackMode.Percentage,
+                    AlwaysShowLabels = true
+                },
+                new StackedColumnSeries
+                {
+                    Values = new ChartValues<ObservableValue>
+                    {
+                        new ObservableValue(0)
+                    },
+                    DataLabels = true,
+                    StackMode = StackMode.Percentage,
+                    AlwaysShowLabels = true
+                },
+                new StackedColumnSeries
+                {
+                    Values = new ChartValues<ObservableValue>
+                    {
+                        new ObservableValue(900)
+                    },
+                    DataLabels = true,
+                    StackMode = StackMode.Percentage,
+                    AlwaysShowLabels = true
+                },
+                new StackedColumnSeries
+                {
+                    Values = new ChartValues<ObservableValue>
+                    {
+                    new ObservableValue(15)
+                    },
+                    DataLabels = true,
+                    StackMode = StackMode.Percentage,
+                    AlwaysShowLabels = true
+                }
+            };
+
+            SeriesCollectionPercentage = new SeriesCollection
+            {
+                new StackedColumnSeries
+                {
+                    Values = new ChartValues<ObservableValue>
+                    {
+                        new ObservableValue(1)
+                    },
+                    DataLabels = true,
+                    StackMode = StackMode.Percentage,
+                },
+                new StackedColumnSeries
+                {
+                    Values = new ChartValues<ObservableValue>
+                    {
+                        new ObservableValue(250)
+                    },
+                    DataLabels = true,
+                    StackMode = StackMode.Percentage,
+                },
+                new StackedColumnSeries
+                {
+                    Values = new ChartValues<ObservableValue>
+                    {
+                        new ObservableValue(0)
+                    },
+                    DataLabels = true,
+                    StackMode = StackMode.Percentage
+                },
+                new StackedColumnSeries
+                {
+                    Values = new ChartValues<ObservableValue>
+                    {
+                        new ObservableValue(900)
+                    },
+                    DataLabels = true,
+                    StackMode = StackMode.Percentage
+                },
+                new StackedColumnSeries
+                {
+                    Values = new ChartValues<ObservableValue>
+                    {
+                        new ObservableValue(15)
+                    },
+                    DataLabels = true,
+                    StackMode = StackMode.Percentage
+                }
+            };
+
+            SeriesCollectionAlwaysShowValues = new SeriesCollection
+            {
+                new StackedColumnSeries
+                {
+                    Values = new ChartValues<ObservableValue>
+                    {
+                        new ObservableValue(1)
+                    },
+                    DataLabels = true,
+                    StackMode = StackMode.Values,
+                    AlwaysShowLabels = true
+                },
+                new StackedColumnSeries
+                {
+                    Values = new ChartValues<ObservableValue>
+                    {
+                        new ObservableValue(250)
+                    },
+                    DataLabels = true,
+                    StackMode = StackMode.Values,
+                    AlwaysShowLabels = true
+                },
+                new StackedColumnSeries
+                {
+                    Values = new ChartValues<ObservableValue>
+                    {
+                        new ObservableValue(0)
+                    },
+                    DataLabels = true,
+                    StackMode = StackMode.Values,
+                    AlwaysShowLabels = true
+                },
+                new StackedColumnSeries
+                {
+                    Values = new ChartValues<ObservableValue>
+                    {
+                        new ObservableValue(900)
+                    },
+                    DataLabels = true,
+                    StackMode = StackMode.Values,
+                    AlwaysShowLabels = true
+                },
+                new StackedColumnSeries
+                {
+                    Values = new ChartValues<ObservableValue>
+                    {
+                    new ObservableValue(15)
+                    },
+                    DataLabels = true,
+                    StackMode = StackMode.Values,
+                    AlwaysShowLabels = true
+                }
+            };
+
+            SeriesCollectionValues = new SeriesCollection
+            {
+                new StackedColumnSeries
+                {
+                    Values = new ChartValues<ObservableValue>
+                    {
+                        new ObservableValue(1)
+                    },
+                    DataLabels = true,
+                    StackMode = StackMode.Values
+                },
+                new StackedColumnSeries
+                {
+                    Values = new ChartValues<ObservableValue>
+                    {
+                        new ObservableValue(250)
+                    },
+                    DataLabels = true,
+                    StackMode = StackMode.Values
+                },
+                new StackedColumnSeries
+                {
+                    Values = new ChartValues<ObservableValue>
+                    {
+                        new ObservableValue(0)
+                    },
+                    DataLabels = true,
+                    StackMode = StackMode.Values
+                },
+                new StackedColumnSeries
+                {
+                    Values = new ChartValues<ObservableValue>
+                    {
+                        new ObservableValue(900)
+                    },
+                    DataLabels = true,
+                    StackMode = StackMode.Values
+                },
+                new StackedColumnSeries
+                {
+                    Values = new ChartValues<ObservableValue>
+                    {
+                        new ObservableValue(15)
+                    },
+                    DataLabels = true,
+                    StackMode = StackMode.Values
+                }
+            };
+
+            Labels = new[]
+            {
+                "Jan", "Feb","Mar", "Apr", "May", "Jun", "Jul", "Ago"
+            };
+
+            DataContext = this;
+        }
+
+        public SeriesCollection SeriesCollectionAlwaysShowPercentage { get; set; }
+        public SeriesCollection SeriesCollectionPercentage { get; set; }
+        public SeriesCollection SeriesCollectionAlwaysShowValues { get; set; }
+        public SeriesCollection SeriesCollectionValues { get; set; }
+        public string[] Labels { get; set; }
+    }
+}

--- a/Examples/Wpf/Home/HomeViewModel.cs
+++ b/Examples/Wpf/Home/HomeViewModel.cs
@@ -83,7 +83,8 @@ namespace Wpf.Home
                         new SampleVm("Energy Predictions", typeof(EnergyPredictionExample)),
                         new SampleVm("Funnel Chart", typeof(FunnelExample)),
                         new SampleVm("Point Stroke", typeof(PointStrokeExample)),
-                        new SampleVm("Point StrokeDashArray", typeof(PointStrokeDashArrayExample)) 
+                        new SampleVm("Point StrokeDashArray", typeof(PointStrokeDashArrayExample)),
+                        new SampleVm("Always Show Labels", typeof(StackedColumnAlwaysShowLabelExample))
                     }
                 },
                 new SampleGroupVm

--- a/WpfView/StackedColumnSeries.cs
+++ b/WpfView/StackedColumnSeries.cs
@@ -68,6 +68,24 @@ namespace LiveCharts.Wpf
         #region Properties
 
         /// <summary>
+        ///   Option to always show the labels for a stack column series.
+        /// </summary>
+        /// <remarks>
+        ///   N.B. This will force the graph to not be percentage accurate.
+        /// </remarks>
+        public static readonly DependencyProperty AlwaysShowLabelsProperty = DependencyProperty.Register(
+            "AlwaysShowLabels", typeof(bool), typeof(StackedColumnSeries), new PropertyMetadata(default(bool)));
+
+        /// <summary>
+        ///   Gets or sets the always show labels property.
+        /// </summary>
+        public bool AlwaysShowLabels
+        {
+            get { return (bool)GetValue(AlwaysShowLabelsProperty); }
+            set { SetValue(AlwaysShowLabelsProperty, value); }
+        }
+
+        /// <summary>
         /// The maximum column width property
         /// </summary>
         public static readonly DependencyProperty MaxColumnWidthProperty = DependencyProperty.Register(


### PR DESCRIPTION
#### Summary

Added a new property `AlwaysShowLabels` for `StackedColumnSeries`.  

It works for `Percentage` and `Value` modes.

If the value is zero then it will still hide the label.

Note it will make the graph not accurate representation as it forces space for the labels.

![image](https://user-images.githubusercontent.com/19693277/95024937-04bbe200-067e-11eb-8eac-349da00e7ef9.png)

_Probably not my most efficient code; was a means to an end._

#### Solves 

It solves #1094
