### PR TITLE
Fixed Fill and Stroke for StackedColumnSeries with Mapper.

### DIFF
--- a/Examples/Wpf/CartesianChart/PointState/PointStateExample.xaml
+++ b/Examples/Wpf/CartesianChart/PointState/PointStateExample.xaml
@@ -9,16 +9,28 @@
              d:DesignHeight="300" d:DesignWidth="300" d:DataContext="{d:DesignInstance pointState:PointStateExample}">
     <Grid>
         <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"></RowDefinition>
-            <RowDefinition Height="*"></RowDefinition>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <Button Grid.Row="0" Click="UpdateDataOnClick">Update Data</Button>
+        
+        <Button Grid.Row="0" 
+                Content="Update Data" 
+                Click="UpdateDataOnClick" />
+
         <lvc:CartesianChart Grid.Row="1">
             <lvc:CartesianChart.Series>
                 <lvc:LineSeries Values="{Binding Values}" 
                                 PointGeometrySize="20" 
                                 PointForeground="White"
-                                Configuration="{Binding Mapper}"/>
+                                Configuration="{Binding Mapper}" />
+            </lvc:CartesianChart.Series>
+        </lvc:CartesianChart>
+
+        <lvc:CartesianChart Grid.Row="2">
+            <lvc:CartesianChart.Series>
+                <lvc:StackedColumnSeries Values="{Binding Values}" 
+                                         Configuration="{Binding Mapper}" />
             </lvc:CartesianChart.Series>
         </lvc:CartesianChart>
     </Grid>

--- a/WpfView/StackedColumnSeries.cs
+++ b/WpfView/StackedColumnSeries.cs
@@ -230,6 +230,9 @@ namespace LiveCharts.Wpf
                 pbv.DataLabel = null;
             }
 
+            if (point.Stroke != null) pbv.Rectangle.Stroke = (Brush)point.Stroke;
+            if (point.Fill != null) pbv.Rectangle.Fill = (Brush)point.Fill;
+
             pbv.LabelPosition = LabelsPosition;
 
             return pbv;


### PR DESCRIPTION
#### Summary

Extended the `PointState` example to also include `StackedColumnSeries` along side the `LineSeries` and fixed the `StackedColumnSeries` so with a Mapper it sets the `Fill` and `Stroke` correctly.

![image](https://user-images.githubusercontent.com/19693277/95026857-2623ca80-068c-11eb-810d-890d4a90ea54.png)

#### Solves 

It solves #1095.
